### PR TITLE
Expands OpenSearchSink to allow for minimum logging levels and logging level switches

### DIFF
--- a/AppFact.SerilogOpenSearchSink/SerilogExtensions.cs
+++ b/AppFact.SerilogOpenSearchSink/SerilogExtensions.cs
@@ -24,7 +24,7 @@ public static class SerilogExtensions
     public static LoggerConfiguration OpenSearch(this LoggerSinkConfiguration configuration,
         IConnectionSettingsValues settings,
         OpenSearchSinkOptions options = default!,
-        LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         LoggingLevelSwitch? levelSwitch = null)
     {
         _ = configuration ?? throw new ArgumentNullException(nameof(configuration));
@@ -49,7 +49,7 @@ public static class SerilogExtensions
         string uri,
         string basicAuthUser, string basicAuthPassword, string index = "logs", int? maxBatchSize = 1000,
         double tickInSeconds = 1.0,
-        LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         LoggingLevelSwitch? levelSwitch = null)
     {
         _ = configuration ?? throw new ArgumentNullException(nameof(configuration));

--- a/AppFact.SerilogOpenSearchSink/SerilogExtensions.cs
+++ b/AppFact.SerilogOpenSearchSink/SerilogExtensions.cs
@@ -1,6 +1,8 @@
 using OpenSearch.Client;
 using Serilog;
 using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace AppFact.SerilogOpenSearchSink;
 
@@ -15,14 +17,18 @@ public static class SerilogExtensions
     /// <param name="configuration"></param>
     /// <param name="settings">connection settings</param>
     /// <param name="options">options for how logs are sent to OpenSearch</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
     /// <returns></returns>
     /// <exception cref="ArgumentNullException">when <paramref name="configuration"/> is null</exception>
     public static LoggerConfiguration OpenSearch(this LoggerSinkConfiguration configuration,
         IConnectionSettingsValues settings,
-        OpenSearchSinkOptions options = default!)
+        OpenSearchSinkOptions options = default!,
+        LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose,
+        LoggingLevelSwitch? levelSwitch = null)
     {
         _ = configuration ?? throw new ArgumentNullException(nameof(configuration));
-        return configuration.Sink(new OpenSearchSink(settings, options));
+        return configuration.Sink(new OpenSearchSink(settings, options), restrictedToMinimumLevel, levelSwitch);
     }
 
     /// <summary>
@@ -35,12 +41,16 @@ public static class SerilogExtensions
     /// <param name="index">index where logs are sent to</param>
     /// <param name="maxBatchSize">how many logs (maximum) should be sent to OpenSearch in one single request/on each tick</param>
     /// <param name="tickInSeconds">how often logs are taken from the internal queue and sent to OpenSearch</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when levelSwitch is specified.</param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
     /// <returns></returns>
     /// <exception cref="ArgumentNullException">when required parameters are null. see null annotations</exception>
     public static LoggerConfiguration OpenSearch(this LoggerSinkConfiguration configuration,
         string uri,
         string basicAuthUser, string basicAuthPassword, string index = "logs", int? maxBatchSize = 1000,
-        double tickInSeconds = 1.0)
+        double tickInSeconds = 1.0,
+        LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose,
+        LoggingLevelSwitch? levelSwitch = null)
     {
         _ = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _ = uri ?? throw new ArgumentNullException(nameof(uri));
@@ -58,6 +68,6 @@ public static class SerilogExtensions
             Tick = TimeSpan.FromSeconds(tickInSeconds),
         };
 
-        return configuration.OpenSearch(conn, opts);
+        return configuration.OpenSearch(conn, opts, restrictedToMinimumLevel, levelSwitch);
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ cs.DefaultIndex("logs");
 cs.BasicAuthentication("username", "password");
 // register sink
 builder.WriteTo.OpenSearch(cs);
-// or
-builder.WriteTo.OpenSearch(cs, new OpenSearchSinkOptions{...});
+// also supports optional parameters options, restrictedToMinimumLevel, and levelSwitch
+builder.WriteTo.OpenSearch(cs, options: new OpenSearchSinkOptions{...}, restrictedToMinimumLevel: LevelAlias.Minimum, levelSwitch: new Serilog.Core.LoggingLevelSwitch());
 
 // method 2
 // or configure without IConnectionSettingsValues using basic auth
@@ -38,7 +38,9 @@ builder.WriteTo.OpenSearch(
     basicAuthPassword: "password",
     index: "logs", // optional, default is "logs"
     maxBatchSize: 1000, // optional and nullable, default is 1000
-    tickInSeconds: 1.0 // optional double, default is 1.0
+    tickInSeconds: 1.0, // optional double, default is 1.0
+	restrictedToMinimumLevel: LevelAlias.Minimum, // optional enumerator, default is LevelAlias.Minimum
+    levelSwitch: null // optional Serilog.Core.LoggingLevelSwitch, default is null
 );
 
 


### PR DESCRIPTION
- Added a `LogEventLevel` and `LoggingLevelSwitch` parameter to the OpenSearchSink constructor to allow for a minimum log level to be specified for reporting to OpenSearch.