### PR TITLE
Add extension for sniffing connection pool

### DIFF
--- a/AppFact.SerilogOpenSearchSink/SerilogExtensions.cs
+++ b/AppFact.SerilogOpenSearchSink/SerilogExtensions.cs
@@ -118,13 +118,12 @@ public static class SerilogExtensions
 
         var conn = new ConnectionSettings(connectionPool);
 
-        conn.ServerCertificateValidationCallback(static (_, _, _, _) => true);
         conn.BasicAuthentication(basicAuthUser, basicAuthPassword);
         conn.DefaultIndex(index);
 
         if (bypassSsl)
         {
-            conn.ServerCertificateValidationCallback(static (_, _, _, _) => true);
+            conn.ServerCertificateValidationCallback(CertificateValidations.AllowAll);
         }
 
         var opts = new OpenSearchSinkOptions()

--- a/AppFact.SerilogOpenSearchSink/SerilogExtensions.cs
+++ b/AppFact.SerilogOpenSearchSink/SerilogExtensions.cs
@@ -85,7 +85,7 @@ public static class SerilogExtensions
     /// <param name="bypassSsl">Bypass OpenSearch node SSL certificate if it's untrusted. Default behaviour for .NET is to throw exception in such cases.</param>
     /// <returns></returns>
     static public LoggerConfiguration OpenSearch(this LoggerSinkConfiguration configuration,
-        IEnumerable<Uri> connectionStrings,
+        ICollection<Uri> connectionStrings,
         string basicAuthUser,
         string basicAuthPassword,
         string index = "logs",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ builder.WriteTo.OpenSearch(cs, options: new OpenSearchSinkOptions{...}, restrict
 // or configure without IConnectionSettingsValues using basic auth
 // provides less flexibility but works with Serilog.Settings.Configuration
 builder.WriteTo.OpenSearch(
-    uri: "http://localhost:9200", // or provide several Uris for 
+    uri: "http://localhost:9200", // or submit several see method 2 with SniffingConnectionPool
     basicAuthUser: "username",
     basicAuthPassword: "password",
     index: "logs", // optional, default is "logs"
@@ -44,9 +44,9 @@ builder.WriteTo.OpenSearch(
     bypassSsl: false // .NET will throw an exception when a server certificate is issued by an untrasted authority. To bypass the SSL certificate check set the value to true, default is false
 );
 
-// method 2 with
+// method 2 with SniffingConnectionPool
 builder.WriteTo.OpenSearch(
-    connectionStrings: new Uri[] // provide several URIs for SniffingConnectionPool
+    connectionStrings: new Uri[]
     {
         new Uri("http://localhost:9200"),
         new Uri("http://localhost:9201"),

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ builder.WriteTo.OpenSearch(cs, options: new OpenSearchSinkOptions{...}, restrict
 // or configure without IConnectionSettingsValues using basic auth
 // provides less flexibility but works with Serilog.Settings.Configuration
 builder.WriteTo.OpenSearch(
-    uri: "http://localhost:9200",
+    uri: "http://localhost:9200", // or provide several Uris for 
     basicAuthUser: "username",
     basicAuthPassword: "password",
     index: "logs", // optional, default is "logs"
@@ -42,6 +42,17 @@ builder.WriteTo.OpenSearch(
     restrictedToMinimumLevel: LevelAlias.Minimum, // optional enumerator, default is LevelAlias.Minimum
     levelSwitch: null, // optional Serilog.Core.LoggingLevelSwitch, default is null
     bypassSsl: false // .NET will throw an exception when a server certificate is issued by an untrasted authority. To bypass the SSL certificate check set the value to true, default is false
+);
+
+// method 2 with
+builder.WriteTo.OpenSearch(
+    connectionStrings: new Uri[] // provide several URIs for SniffingConnectionPool
+    {
+        new Uri("http://localhost:9200"),
+        new Uri("http://localhost:9201"),
+        new Uri("http://localhost:9202")
+    },
+    // the rest of parameters
 );
 
 


### PR DESCRIPTION
## [Background]

Adding support for [SniffingConnectionPool](https://opensearch.org/docs/latest/clients/dot-net-conventions/#connection-pools) as it's the most used setup after SingleNodeConnectionPool. Updatign extensions so if multiple connection strings are added, utlize SniffingConnectionPool